### PR TITLE
Added R+Tidyverse ws, changed header title

### DIFF
--- a/content/workshops/_index.md
+++ b/content/workshops/_index.md
@@ -18,7 +18,8 @@ If the workshop has happened, take the comment brackets away et voilá! -->
 
 ### 2021
 
-#### Carpentry Mini-workshops
+#### Online self-organized workshops
+* May [Carpentry@UiO Data Analysis and Visualization in R and Tidyverse (Novices)](https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/time-and-place/210525_r) - online
 * March [Carpentry: Plotting and Programming with Python (Novices)](https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/time-and-place/210302_python) - online
 * January [Carpentry pilot Workshop (Online): Introduction to Conda for (Data) Scientists](https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/time-and-place/210108_conda) - joint coordination by Digital Scholarship Center, CodeRefinery, Finnish Geospatial Research Institute FGI , UiT: The Arctic University of Norway and Aalto University - online
 

--- a/content/workshops/_index.md
+++ b/content/workshops/_index.md
@@ -18,7 +18,7 @@ If the workshop has happened, take the comment brackets away et voilá! -->
 
 ### 2021
 
-#### Online self-organized workshops
+#### Carpentry Mini-workshops
 * May [Carpentry@UiO Data Analysis and Visualization in R and Tidyverse (Novices)](https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/time-and-place/210525_r) - online
 * March [Carpentry: Plotting and Programming with Python (Novices)](https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/time-and-place/210302_python) - online
 * January [Carpentry pilot Workshop (Online): Introduction to Conda for (Data) Scientists](https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/time-and-place/210108_conda) - joint coordination by Digital Scholarship Center, CodeRefinery, Finnish Geospatial Research Institute FGI , UiT: The Arctic University of Norway and Aalto University - online


### PR DESCRIPTION
Workshops in 2021 so far are not necessarily Carpentries core lesson-based. Also, online workshops are not necessarily 1 day. So I would suggest changing the title to more precisely describing one.