### PR TITLE
Fix feed for upcoming workshops

### DIFF
--- a/content/workshops/_index.md
+++ b/content/workshops/_index.md
@@ -9,7 +9,7 @@ Inbetween workshops we meet for study groups. To learn more about the study grou
 
 ## Upcoming Workshops
 
-{{< event-feed "https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/time-and-place/?vrtx=feed" >}}
+{{< event-feed "https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/?vrtx=feed" >}}
 
 
 ## Past Workshops


### PR DESCRIPTION
The current url goes to an outdated page. I tested with this new one locally and it there it works: it shows the upcoming workshops from the new url.