### PR TITLE
add alumni to member list

### DIFF
--- a/content/about/members.md
+++ b/content/about/members.md
@@ -51,3 +51,11 @@ For more information, [contact us](mailto:contact-us@carpentry.uio.no).
 * [Sunniva Indrehus ](http://github.com/sunnivin)
 * [Heidi Karlsen](http://github.com/heidikarlsen)
 * [Agata Bochynska](http://github.com/agboch)
+
+## Alumni
+
+* [Michel Heeremans](http://github.com/heereman)
+* [Gladys Nalvarte](http://github.com/GladysNalvarte)
+* [Eve Zeyl Fiskebeck](http://github.com/evezeyl)
+* [Eszter A. Papp](http://github.com/eapapp)
+* [Tina Visnovska](http://github.com/tinavisnovska)


### PR DESCRIPTION
I've added all people from the study group member list who were not on already on the current *Comunity Members" list to an "Alumni" list, as suggested by @arockenberger
I don't have a good overview of who is an active member or alumni, and I don't know if all of them want to be listed here. Can someone else review and make changes if necessary, please?
When finished, this should close #20