### PR TITLE
Update deploy-to-gh-pages.yaml

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yaml
+++ b/.github/workflows/deploy-to-gh-pages.yaml
@@ -12,7 +12,7 @@ on:
       - master
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
Based on the recommendation described in the error message, edited the ubuntu version to 22.04