### PR TITLE
fix(ui): Upcoming events are shown again.

### DIFF
--- a/layouts/shortcodes/event-feed.html
+++ b/layouts/shortcodes/event-feed.html
@@ -1,6 +1,11 @@
 {{ $feedurl := (.Get 0) }}
 {{ $jsonurl := (printf "https://api.factmaven.com/xml-to-json/?xml=%s" $feedurl) }}
-<!-- Converts xml to json. Alternative API: "https://api.rss2json.com/v1/api.json?rss_url=%s" -->
+<!-- Converts xml to json. Alternative API: "https://api.rss2json.com/v1/api.json?rss_url=%s" 
+  currently using this JSON feed:
+  https://api.factmaven.com/xml-to-json/?xml=https://www.ub.uio.no/english/courses-events/courses/other/Carpentry/?vrtx=feed
+-->
+
+
 
 {{ $res := getJSON $jsonurl }}
 
@@ -16,20 +21,22 @@
 
     <div class="event-feed">
     {{ range $entries }}
-        {{ $start := index . "event-start" | time.Format "2 January 2006" }}
-        {{ $end   := index . "event-end" | time.Format "2 January 2006 15:04" }}
-        {{ $title := index .title.text }}
-        {{ $link  := index .link "href" }}
-        {{ $loc   := index . "event-location" }}
+        {{ $start   := index . "event-start" | time.Format "2 January 2006" }}
+        {{ $end     := index . "event-end" | time.Format "2 January 2006 15:04" }}
+        {{ $title   := index .title.text }}
+        {{ $link    := index .link "href" }}
+        {{ $loc     := index . "event-location" }}
+        {{/*  {{ $descr   := index .summary.div "p"}}
+        {{ $summary := index $descr }}  */}}
 
         <h3><a href="{{ $link }}">{{ $title }}</a></h3>
         <p>
             {{ $start }}<!-- &ndash; {{ $end }} -->, {{ $loc }}
         </p>
-        <p>
-            {{ index .summary.div "p"  | plainify }}
-            <a href="{{ $link }}">(more &hellip;)</a>
-        </p>
+        {{/* <p>
+          {{ $summary }}
+          <a href="{{ $link }}">(more &hellip;)</a>
+        </p>  */}}
     {{ end }}
     </div>
 


### PR DESCRIPTION
fix(ui): Events are shown again. The problem was caused by a parsing error of  event descriptions with links in it. As a quick fix, the event description is not shown anymore. and the github action should work again.

The "upcoming events shortcode" converts the vortex xml feed into a JSON using an API. The summary/description text was then extracted from the JSON. This worked fine unti one of the descriptions contained a link. Links are converted to nested levels of JSON. See image:

![image](https://user-images.githubusercontent.com/3391092/199243939-70603bed-82d5-404e-acfe-3bdea180b6bd.png)

The shortcode was unable to "plainify" this nested JSON and crashed. As a quick fix, I have removed the description from the output. 

**A proper fix would be to filter the nested "p" structure for all "text" fields and paste them together.
The code is commented out, in case anyone wants to dive into Hugo and figure out how to do this later. I currently have no capacity for it.**

Itnow looks like this:
![image](https://user-images.githubusercontent.com/3391092/199245002-cd2fed21-4838-494c-9876-665df8d600e5.png)


fixes #57