### PR TITLE
Term length changed to 2 years, optionally 1 year

### DIFF
--- a/content/about/charter.md
+++ b/content/about/charter.md
@@ -6,7 +6,7 @@ This charter describes our procedures and regulations.
 
 The organisation's board is made up of 8 members:
 
-- 6 members elected for 3 year terms. 
+- 6 members elected for 2 year terms, or optionally 1 year terms upon request by the candidate
 - 2 members are designated by the UiO Library and Digital Scholarship Centre
 
 Elections will be organized every year for renewing two of the elected
@@ -71,7 +71,7 @@ The criteria for individuals to stand for election to the board are:
     helper, instructor, organizer, board member or host) at UiO or elsewhere in the
     past 3 years
 
-Board members will not serve for more than two consecutive three year terms,
+Board members will not serve for more than two consecutive two year terms,
 followed by at least a one year hiatus before serving any new term(s).
 
 Elections will be held at an annual community meeting each year

--- a/content/about/charter.md
+++ b/content/about/charter.md
@@ -4,13 +4,12 @@ This charter describes our procedures and regulations.
 
 ## Organization
 
-The organisation's board is made up of 8 members:
+The organisation's board consists of up to 8 members:
 
-- 6 members elected for 2 year terms, or optionally 1 year terms upon request by the candidate
-- 2 members are designated by the UiO Library and Digital Scholarship Centre
+- 6 members elected for 2-year terms, or optionally 1-year terms upon request by the candidate
+- 2 members are appointed by the UiO Library and Digital Scholarship Centre
 
-Elections will be organized every year for renewing two of the elected
-members of the board.
+Elections will be organized every year for renewing members of the board.
 Board terms start January 1st.
 
 At the first meeting of the new board after the election,
@@ -47,7 +46,7 @@ Responsibilities of each officer of the board are as follows:
 
 ### Communications officer
 
-- Receive all communication from community to the board and relay as
+- Receive all communication from the community to the board and relay as
   necessary
   - Mentoring instructor trainees towards certification and teaching
 
@@ -66,13 +65,13 @@ Responsibilities of each officer of the board are as follows:
 
 The criteria for individuals to stand for election to the board are:
 
-- Is a member of the Carpentry@UiO, broadly defined
+- Is a member of Carpentry@UiO, broadly defined
 - Has participated in a Carpentries event in any capacity (learner,
     helper, instructor, organizer, board member or host) at UiO or elsewhere in the
     past 3 years
 
-Board members will not serve for more than two consecutive two year terms,
-followed by at least a one year hiatus before serving any new term(s).
+Board members will not serve for more than two consecutive two-year terms,
+followed by at least a one-year hiatus before serving any new term(s).
 
 Elections will be held at an annual community meeting each year
 preferably taking place in November or December.
@@ -93,7 +92,7 @@ to fill such a vacancy.
 ## Amendments to the Charter
 
 Amendments to the charter can be proposed by existing board members in
-writing in advance of any board meeting.
+writing before any board meeting.
 
 Amendments require a 2/3 majority vote to be accepted.
 


### PR DESCRIPTION
Changes to the charter motivated by potential candidates for the board. Three years, as introduced in 2023, feels too long for people with temporary contracts, as most of UiO carpentry members have. The proposed changes try to accommodate this and allow for more flexibility, so that members with less than two years left at UiO are nevertheless eligible to join the board.